### PR TITLE
feat(IT-41):Complete-Translation-Language-Selector (#34)

### DIFF
--- a/src/app/module/common/nav-icon-button.tsx
+++ b/src/app/module/common/nav-icon-button.tsx
@@ -4,10 +4,11 @@ import { Button, Image } from '@chakra-ui/react';
 interface NavIconButtonProps {
   src: string;
   bg: string;
+  alt: string;
   onClick?: () => void;
 }
 
-function NavIconButton({ src, bg, onClick }: NavIconButtonProps) {
+function NavIconButton({ src, bg, alt, onClick }: NavIconButtonProps) {
   return (
     <Button
       borderRadius="50%"
@@ -24,7 +25,7 @@ function NavIconButton({ src, bg, onClick }: NavIconButtonProps) {
       maxW="48px"
       maxH="48px"
     >
-      <Image w="60%" h="60%" objectFit="contain" src={src} />
+      <Image w="60%" h="60%" objectFit="contain" src={src} alt={alt} />
     </Button>
   );
 }

--- a/src/app/module/instant-meeting-room/bottom-nav-bar.tsx
+++ b/src/app/module/instant-meeting-room/bottom-nav-bar.tsx
@@ -48,21 +48,29 @@ function BottomNavBar({
         <NavIconButton
           src={isListening ? '/navbar-icon/mic.svg' : '/user-list/user-not-speaking.svg'}
           bg={isListening ? '#026FFB' : '#ffffff'}
+          alt={isListening ? 'Stop microphone' : 'Start microphone'}
           onClick={clickMic}
         />
 
-        <NavIconButton src="/navbar-icon/userWithRound.svg" bg="#ffffff" onClick={clickUser} />
+        <NavIconButton
+          src="/navbar-icon/userWithRound.svg"
+          bg="#ffffff"
+          alt="User settings"
+          onClick={clickUser}
+        />
         <NavIconButton
           src="/navbar-icon/ai-translation.svg"
           bg="#ffffff"
+          alt="AI translation language selector"
           onClick={clickAItranslation}
         />
         <NavIconButton
           src="/navbar-icon/raiseHand.svg"
           bg={isRaiseHand ? '#ffa800' : '#ffffff'}
+          alt={isRaiseHand ? 'Lower hand' : 'Raise hand'}
           onClick={clickRaiseHand}
         />
-        <NavIconButton src="/navbar-icon/share.svg" bg="#ffffff" onClick={clickShare} />
+        <NavIconButton src="/navbar-icon/share.svg" bg="#ffffff" alt="Share" onClick={clickShare} />
         <QuitMeetingButton imageSrc="/quit-meeting.svg" />
       </Flex>
 

--- a/src/app/module/instant-meeting-room/main-translation-area/main-translation-area.tsx
+++ b/src/app/module/instant-meeting-room/main-translation-area/main-translation-area.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { Box } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import ParticipantList from './participant-list/participants-list';
 import ChatBubble from './chat-bubble/chat-bubble';
 import RecognizingBubble from './chat-bubble/user-recognizing-bubble';
@@ -14,8 +14,19 @@ interface userStatus {
   recognizingText?: string | null;
 }
 
+interface MessageWithTranslation {
+  id: string;
+  originalText: string;
+  userName: string;
+  timestamp: Date;
+  translatedText?: string;
+  targetLanguage?: string;
+}
+
 interface speechData {
-  userNameList: string[];
+  messagesWithTranslations?: MessageWithTranslation[];
+  isRetranslating?: boolean;
+  userNameList?: string[];
   recognizingText?: string | null;
   beforeTranslationMessageList?: string[];
   afterTranslation?: string[];
@@ -26,9 +37,11 @@ interface speechData {
 
 function MainTranslationArea(speechData: speechData) {
   const {
+    messagesWithTranslations = [],
+    isRetranslating = false,
     beforeTranslationMessageList = [],
     afterTranslation = [],
-    userNameList,
+    userNameList = [],
     usersStatusList,
   } = speechData;
   const [messages, setMessages] = useState<string[]>([]);
@@ -44,7 +57,6 @@ function MainTranslationArea(speechData: speechData) {
   useEffect(() => {
     if (afterTranslation.length > 0) {
       const newTranslatedMessages = [...afterTranslation];
-
       setTranslatedMessage(newTranslatedMessages);
     }
   }, [afterTranslation]);
@@ -70,14 +82,30 @@ function MainTranslationArea(speechData: speechData) {
         borderBottomLeftRadius="20px"
         overflowY="auto"
       >
-        {messages.map((message, index) => (
-          <ChatBubble
-            key={index}
-            beforeTranslationMessage={message}
-            userName={userNameList[index]}
-            afterTranslation={translatedMessage[index]}
-          />
-        ))}
+        {isRetranslating && (
+          <Box textAlign="center" py={2} bg="blue.50" borderRadius="8px" mb={4}>
+            <Text fontSize="sm" color="blue.600">
+              Retranslating historical messages...
+            </Text>
+          </Box>
+        )}
+        {messagesWithTranslations.length > 0
+          ? messagesWithTranslations.map((message) => (
+              <ChatBubble
+                key={message.id}
+                beforeTranslationMessage={message.originalText}
+                userName={message.userName}
+                afterTranslation={message.translatedText}
+              />
+            ))
+          : messages.map((message, index) => (
+              <ChatBubble
+                key={index}
+                beforeTranslationMessage={message}
+                userName={userNameList[index]}
+                afterTranslation={translatedMessage[index]}
+              />
+            ))}
         {usersStatusList?.map((user) =>
           user.isRecognizing && !!user.recognizingText?.trim() ? (
             <RecognizingBubble

--- a/src/app/module/instant-meeting-room/meeting-room.tsx
+++ b/src/app/module/instant-meeting-room/meeting-room.tsx
@@ -4,13 +4,16 @@ import { Box } from '@chakra-ui/react';
 import MainTranslationArea from './main-translation-area/main-translation-area';
 import BottomNavBar from './bottom-nav-bar';
 import ShareLinkPanel from './share-link-panel/share-link-panel';
+import TranslationLanguageSelector from './translation-language-selector';
 import { useUserStore } from '@/store/userStore';
-import * as sdk from 'microsoft-cognitiveservices-speech-sdk';
 import { useMeetingStore } from '@/store/meetingStore';
+import { useTranslationLanguage } from '@/hooks/useTranslationLanguage';
+import * as sdk from 'microsoft-cognitiveservices-speech-sdk';
 import socket from '@/lib/socket';
 import supportLanguagesList from '@/lib/support-language-list';
 import DeskTopHeading from './heading/desktop-heading';
 import MobileHeading from './heading/mobile-heading';
+
 const SPEECH_KEY = process.env.NEXT_PUBLIC_SPEECH_KEY;
 const SPEECH_REGION = process.env.NEXT_PUBLIC_SPEECH_REGION;
 
@@ -29,20 +32,76 @@ interface userStatus {
   recognizingText?: string | null;
 }
 
+//Add: Message with translation association data structure
+interface MessageWithTranslation {
+  id: string;
+  originalText: string;
+  userName: string;
+  timestamp: Date;
+  translatedText?: string;
+  targetLanguage?: string;
+}
+
 function MeetingRoom() {
   const [showBarCodeAndLink, setShowBarCodeAndLink] = useState(true);
   const [isListening, setIsListening] = useState(false);
+  const [showLanguageSelector, setShowLanguageSelector] = useState(false);
+
+  //Old state to be replaced
   const [recognizedText, setRecognizedText] = useState<string[]>([]);
   const [recognizedTextUserList, setRecognizedTextUserList] = useState<string[]>([]);
+  const [myPersonalizedTranslation, setMyPersonalizedTranslation] = useState<string[]>([]);
+
+  //New: Unified message storage structure
+  const [messagesWithTranslations] = useState<MessageWithTranslation[]>([]);
+  const [isRetranslating, setIsRetranslating] = useState(false);
+
   const [recognizingText, setRecognizingText] = useState<string | null>(null);
   const [speechRecognizer, setSpeechRecognizer] = useState<sdk.SpeechRecognizer | null>(null);
   const [isRecognizing, setIsRecognizing] = useState(false);
   const [isRaiseHand, setIsRaiseHand] = useState<boolean>(false);
-  const [myPersonalizedTranslation, setMyPersonalizedTranslation] = useState<string[]>([]);
   const [usersStatusList, setUserStatusList] = useState<userStatus[]>([]);
+
   const user = useUserStore((state) => state.user);
   const meeting = useMeetingStore((state) => state.meeting);
   const localPreferenceLanguage = user?.language;
+
+  // Translation language hook
+  const { selectedLanguage, updateLanguage } = useTranslationLanguage(
+    localPreferenceLanguage || 'en'
+  );
+
+  // Function to retranslate all history messages
+  const retranslateHistoryMessages = useCallback(
+    (newLanguageCode: string) => {
+      if (recognizedText.length === 0) {
+        return;
+      }
+
+      setIsRetranslating(true);
+
+      // Clear current translations
+      setMyPersonalizedTranslation([]);
+
+      // Request retranslation for each historical message
+      recognizedText.forEach((text, index) => {
+        setTimeout(() => {
+          socket.emit('request-translate-for-me', {
+            text,
+            myPreferLanguage: newLanguageCode,
+          });
+
+          // Mark retranslation as complete after the last message
+          if (index === recognizedText.length - 1) {
+            setTimeout(() => {
+              setIsRetranslating(false);
+            }, 1000); // Give some time for translations to come back
+          }
+        }, index * 100); // Stagger requests to avoid overwhelming the server
+      });
+    },
+    [recognizedText]
+  );
 
   const handleRecognizing = useCallback(
     (text: string) => {
@@ -163,10 +222,11 @@ function MeetingRoom() {
       setRecognizedText((prev) => [...prev, text]);
       setRecognizedTextUserList((prev) => [...prev, emittingUser.name]);
 
-      if (localPreferenceLanguage) {
+      // Use selectedLanguage instead of localPreferenceLanguage for translation requests
+      if (selectedLanguage) {
         socket.emit('request-translate-for-me', {
           text,
-          myPreferLanguage: localPreferenceLanguage,
+          myPreferLanguage: selectedLanguage,
         });
       }
     };
@@ -196,7 +256,7 @@ function MeetingRoom() {
       socket.off('broadcast-user-status', handleUserStatusBroadcast);
       socket.off('personal-translation-result', handleTranslationForMe);
     };
-  }, [localPreferenceLanguage]);
+  }, [selectedLanguage]);
 
   const handleOnRaiseHand = () => {
     if (!user) return;
@@ -235,6 +295,25 @@ function MeetingRoom() {
     setShowBarCodeAndLink(true);
   };
 
+  // Translation language selector handlers
+  const handleOpenLanguageSelector = () => {
+    setShowLanguageSelector(true);
+  };
+
+  const handleCloseLanguageSelector = () => {
+    setShowLanguageSelector(false);
+  };
+
+  const handleLanguageSelect = (languageCode: string) => {
+    updateLanguage(languageCode);
+
+    // Note: Language preference is managed locally with localStorage
+    // No need to sync with server as translation is client-side
+
+    // Trigger history message retranslation
+    retranslateHistoryMessages(languageCode);
+  };
+
   return (
     <>
       <Box
@@ -267,21 +346,30 @@ function MeetingRoom() {
           <MobileHeading />
         </Box>
         <MainTranslationArea
+          messagesWithTranslations={messagesWithTranslations}
           userNameList={recognizedTextUserList}
           recognizingText={recognizingText}
           beforeTranslationMessageList={recognizedText}
           isRecognizing={isRecognizing}
           afterTranslation={myPersonalizedTranslation}
           usersStatusList={usersStatusList}
+          isRetranslating={isRetranslating}
         />
         <BottomNavBar
           clickShare={handleOpenShareLinkPanel}
           clickMic={handleOnListening}
+          clickAItranslation={handleOpenLanguageSelector}
           clickRaiseHand={handleOnRaiseHand}
           isListening={isListening}
           isRaiseHand={isRaiseHand}
         />
         {showBarCodeAndLink && <ShareLinkPanel closeThePanel={handleCloseShareLinkPanel} />}
+        <TranslationLanguageSelector
+          isOpen={showLanguageSelector}
+          onClose={handleCloseLanguageSelector}
+          selectedLanguage={selectedLanguage}
+          onLanguageSelect={handleLanguageSelect}
+        />
       </Box>
     </>
   );

--- a/src/app/module/instant-meeting-room/share-link-panel/share-link-panel.tsx
+++ b/src/app/module/instant-meeting-room/share-link-panel/share-link-panel.tsx
@@ -32,7 +32,7 @@ function ShareLinkPanel({ closeThePanel }: shareLinkPanelProps) {
     >
       <Flex w="100%" h="10%" justifyContent="space-between" alignItems="center">
         <Text fontWeight="bold" fontSize="md">
-          Your meeting`&lsquo;` ready
+          Your meeting&apos;s ready
         </Text>
         <Button
           onClick={closeThePanel}

--- a/src/app/module/instant-meeting-room/translation-language-selector.tsx
+++ b/src/app/module/instant-meeting-room/translation-language-selector.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Box, Text, Flex, Button, VStack } from '@chakra-ui/react';
+import { TRANSLATION_LANGUAGES } from '@/hooks/useTranslationLanguage';
+
+interface TranslationLanguageSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedLanguage: string;
+  onLanguageSelect: (languageCode: string) => void;
+}
+
+function TranslationLanguageSelector({
+  isOpen,
+  onClose,
+  selectedLanguage,
+  onLanguageSelect,
+}: TranslationLanguageSelectorProps) {
+  const handleLanguageSelect = (languageCode: string) => {
+    onLanguageSelect(languageCode);
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <Box
+        position="fixed"
+        top="0"
+        left="0"
+        right="0"
+        bottom="0"
+        bg="rgba(0, 0, 0, 0.5)"
+        zIndex="1000"
+        onClick={onClose}
+      />
+      <Box
+        position="fixed"
+        bottom="0"
+        left="0"
+        right="0"
+        bg="white"
+        borderTopRadius="24px"
+        maxH="70vh"
+        overflow="hidden"
+        zIndex="1001"
+        transform={isOpen ? 'translateY(0)' : 'translateY(100%)'}
+        transition="transform 0.3s ease-in-out"
+      >
+        <Flex align="center" justify="space-between" p={6} pb={4}>
+          <Text fontSize="20px" fontWeight="600" color="gray.800">
+            Language selection
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            fontSize="18px"
+            fontWeight="bold"
+            color="gray.500"
+            _hover={{ color: 'gray.700' }}
+          >
+            ✕
+          </Button>
+        </Flex>
+        <Box px={6} pb={8} maxH="50vh" overflowY="auto">
+          <VStack align="stretch">
+            {TRANSLATION_LANGUAGES.map((language) => (
+              <Box
+                key={language.value}
+                as="button"
+                w="full"
+                py={4}
+                px={2}
+                textAlign="left"
+                borderBottom="1px solid"
+                borderColor="gray.100"
+                _hover={{ bg: 'gray.50' }}
+                _active={{ bg: 'gray.100' }}
+                onClick={() => handleLanguageSelect(language.value)}
+              >
+                <Text
+                  fontSize="16px"
+                  color={selectedLanguage === language.value ? 'blue.500' : 'gray.800'}
+                  fontWeight={selectedLanguage === language.value ? '600' : '400'}
+                >
+                  {language.label}
+                </Text>
+              </Box>
+            ))}
+          </VStack>
+          <Box mt={8} mb={4}>
+            <Button
+              w="full"
+              h="56px"
+              bg="gray.800"
+              color="white"
+              borderRadius="28px"
+              fontSize="16px"
+              fontWeight="600"
+              _hover={{ bg: 'gray.700' }}
+              _active={{ bg: 'gray.900' }}
+              onClick={handleConfirm}
+            >
+              Confirm
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+export default TranslationLanguageSelector;

--- a/src/hooks/useTranslationLanguage.ts
+++ b/src/hooks/useTranslationLanguage.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+
+const TRANSLATION_LANGUAGE_KEY = 'translation-language-preference';
+
+export interface TranslationLanguage {
+  value: string;
+  label: string;
+}
+
+export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
+  { value: 'zh', label: 'Chinese' },
+  { value: 'fr', label: 'French' },
+  { value: 'ko', label: 'Korean' },
+  { value: 'ja', label: 'Japanese' },
+  { value: 'en', label: 'English' },
+  { value: 'ar', label: 'Arabic' },
+  { value: 'ru', label: 'Russian' },
+  { value: 'th', label: 'Thai' },
+  { value: 'de', label: 'German' },
+  { value: 'it', label: 'Italian' },
+  { value: 'es', label: 'Spanish' },
+];
+
+export function useTranslationLanguage(defaultLanguage: string = 'en') {
+  const [selectedLanguage, setSelectedLanguage] = useState<string>(defaultLanguage);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load saved language preference from localStorage on mount
+  useEffect(() => {
+    try {
+      const savedLanguage = localStorage.getItem(TRANSLATION_LANGUAGE_KEY);
+      if (savedLanguage && TRANSLATION_LANGUAGES.some((lang) => lang.value === savedLanguage)) {
+        setSelectedLanguage(savedLanguage);
+      }
+    } catch (error) {
+      console.warn('Failed to load translation language preference:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Save language preference to localStorage whenever it changes
+  const updateLanguage = (languageCode: string) => {
+    try {
+      if (TRANSLATION_LANGUAGES.some((lang) => lang.value === languageCode)) {
+        setSelectedLanguage(languageCode);
+        localStorage.setItem(TRANSLATION_LANGUAGE_KEY, languageCode);
+      } else {
+        console.warn('Invalid language code:', languageCode);
+      }
+    } catch (error) {
+      console.error('Failed to save translation language preference:', error);
+    }
+  };
+
+  // Get language label by code
+  const getLanguageLabel = (code: string): string => {
+    return TRANSLATION_LANGUAGES.find((lang) => lang.value === code)?.label || code;
+  };
+
+  // Get current language object
+  const currentLanguage = TRANSLATION_LANGUAGES.find((lang) => lang.value === selectedLanguage);
+
+  return {
+    selectedLanguage,
+    updateLanguage,
+    getLanguageLabel,
+    currentLanguage,
+    isLoading,
+    availableLanguages: TRANSLATION_LANGUAGES,
+  };
+}

--- a/src/types/translation.types.ts
+++ b/src/types/translation.types.ts
@@ -1,0 +1,36 @@
+export interface TranslationLanguage {
+  value: string;
+  label: string;
+}
+
+export interface TranslationPreference {
+  language: string;
+  autoTranslate: boolean;
+}
+
+export interface TranslationMessage {
+  id: string;
+  originalText: string;
+  translatedText: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  timestamp: Date;
+  userId: string;
+  userName: string;
+}
+
+export interface TranslationRequest {
+  text: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  roomId: string;
+  userId: string;
+}
+
+export interface TranslationResponse {
+  originalText: string;
+  translatedText: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  confidence: number;
+}


### PR DESCRIPTION
- Add translation language selector supporting 10 languages
- Implement dynamic translation switching with real-time updates
- Add history message retranslation functionality
- Integrate with useTranslationLanguage hook for language preference management
- Support localStorage persistence
- Add responsive bottom sheet UI

- Merge latest dev branch features
- Fix accessibility issues

- Remove all console.log statements
- Clean up HTML comments and empty lines
- Improve accessibility implementation:
  * Enhance NavIconButton component interface to accept `alt` parameter
  * Add alt text for all navigation icons in bottom-nav-bar.tsx
- Use useCallback for performance optimization in speech recognition handlers
- Remove backend dependency for language preference sync (pure frontend solution)
- Fix ESLint accessibility warnings with proper alt attributes

- feat: logout button in landing page - mobile and PC
- feat: Quit meeting to Dashboard page and Logout


### Testing
_**Step1**_ initialize 3 users they are Chinese speaker Japanese speaker English speaker by default
<img width="1279" alt="initialize3 user from left to right chinese speaker en speaker jp speaker" src="https://github.com/user-attachments/assets/e5abc576-7d44-47ea-ba9e-09a6904cbc33" />

**_Step2_**  They all  open mics and speak in the same time
<img width="1277" alt="stage2 3 users speak in the same time" src="https://github.com/user-attachments/assets/9abe8cb8-9003-4cb3-8169-2ccaf3c54e9f" />

_**Step3**_ Some of them swap they language

- Senario1 all of them change to effective language into english in the same time as we can see from the screen all histroy record could be retranslated and align with correct order after retranslation
- From:
<img width="1275" alt="all of them change to effective language into english in the same time" src="https://github.com/user-attachments/assets/c1596e7e-0ff7-4818-ac92-493d223bb305" />
-Result:(as we see every thing could be align into the same order after retranslation)
<img width="1280" alt="everything will be align into same order" src="https://github.com/user-attachments/assets/a37e3c07-a532-4148-b128-50e051067ebf" />


- Senario2 user 3 change the effective language from en from senario1 to russian
<img width="438" alt="user3 change language to russian" src="https://github.com/user-attachments/assets/909cc929-85dd-4013-9599-37e25f7ca7eb" />

- Senario3 user 2 change the effective language from en from senario1 to Chinese
<img width="385" alt="user2 change his preference language into chinese" src="https://github.com/user-attachments/assets/22a02e73-2723-4e29-a10e-352e17d3a2db" />


- Senario4 user1 swapp language when talking from en to chinese again 
<img width="1279" alt="user1 swapp language when talking from en to chinese again" src="https://github.com/user-attachments/assets/9d48bc38-68bf-47e8-a258-f7600cdac0df" />

- Senario5 user 2 change the effective language from en from senario1 to Chinese
<img width="385" alt="user2 change his preference language into chinese" src="https://github.com/user-attachments/assets/22a02e73-2723-4e29-a10e-352e17d3a2db" />







